### PR TITLE
feat: re-use pvc for k8s sidecar charm

### DIFF
--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -223,12 +223,13 @@ func filesystemFromParams(in params.KubernetesFilesystemParams) (*storage.Kubern
 		}
 	}
 	return &storage.KubernetesFilesystemParams{
-		StorageName:  in.StorageName,
-		Provider:     storage.ProviderType(in.Provider),
-		Size:         in.Size,
-		Attributes:   in.Attributes,
-		ResourceTags: in.Tags,
-		Attachment:   attachment,
+		StorageName:   in.StorageName,
+		Provider:      storage.ProviderType(in.Provider),
+		Size:          in.Size,
+		Attributes:    in.Attributes,
+		ResourceTags:  in.Tags,
+		Attachment:    attachment,
+		FileSystemIds: in.FileSystemIds,
 	}, nil
 }
 

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -457,11 +457,12 @@ func (c caasDeployParams) precheck(
 	registry storage.ProviderRegistry,
 	caasBroker CaasBrokerInterface,
 ) error {
-	if len(c.attachStorage) > 0 {
-		return errors.Errorf(
-			"AttachStorage may not be specified for container models",
-		)
-	}
+	// Note(jneo8): Temporary disable the attachStorage check.
+	// if len(c.attachStorage) > 0 {
+	// 	return errors.Errorf(
+	// 		"AttachStorage may not be specified for container models",
+	// 	)
+	// }
 	if len(c.placement) > 1 {
 		return errors.Errorf(
 			"only 1 placement directive is supported for container models, got %d",

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -511,6 +511,12 @@ func (v caasDeployFromRepositoryValidator) ValidateArg(arg params.DeployFromRepo
 	if corecharm.IsKubernetes(dt.charm) && charm.MetaFormat(dt.charm) == charm.FormatV1 {
 		deployRepoLogger.Debugf("DEPRECATED: %q is a podspec charm, which will be removed in a future release", arg.CharmName)
 	}
+	attachStorage, attachStorageErrs := validateAndParseAttachStorage(arg.AttachStorage, dt.numUnits)
+	if len(attachStorageErrs) > 0 {
+		errs = append(errs, attachStorageErrs...)
+	}
+	dt.attachStorage = attachStorage
+
 	// TODO
 	// Convert dt.applicationConfig from Config to a map[string]string.
 	// Config across the wire as a map[string]string no longer exists for

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -564,6 +564,7 @@ func (a *API) applicationFilesystemParams(
 			controllerConfig.ControllerUUID(),
 			modelConfig,
 			a.storagePoolManager, a.registry,
+			a.storage,
 		)
 		if err != nil {
 			return nil, errors.Annotatef(err, "getting filesystem %q parameters", name)
@@ -585,6 +586,7 @@ func (a *API) applicationFilesystemParams(
 			allFilesystemParams = append(allFilesystemParams, *fsParams)
 		}
 	}
+
 	return allFilesystemParams, nil
 }
 
@@ -596,6 +598,7 @@ func filesystemParams(
 	modelConfig *config.Config,
 	poolManager poolmanager.PoolManager,
 	registry storage.ProviderRegistry,
+	storageBackend StorageBackend,
 ) (*params.KubernetesFilesystemParams, error) {
 
 	filesystemTags, err := storagecommon.StorageTags(nil, modelConfig.UUID(), controllerUUID, modelConfig)
@@ -613,9 +616,23 @@ func filesystemParams(
 		return nil, errors.Maskf(err, "getting filesystem storage parameters")
 	}
 
+	fsIds := []string{}
+	filesystems, err := storageBackend.AllFilesystems()
+	if err != nil {
+		return nil, fmt.Errorf("can't get the filesystems %w", err)
+	}
+	for _, fs := range filesystems {
+		fsInfo, err := fs.Info()
+		if err != nil {
+			return nil, fmt.Errorf("can't get storage for filesystem %w", err)
+		}
+		fsIds = append(fsIds, fsInfo.FilesystemId)
+	}
+
 	fsParams.Size = cons.Size
 	fsParams.StorageName = storageName
 	fsParams.Tags = filesystemTags
+	fsParams.FileSystemIds = fsIds
 	return fsParams, nil
 }
 

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -264,7 +264,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		} else if getErr != nil {
 			return errors.Trace(getErr)
 		}
-		storageUniqueID, err := a.getStorageUniqPrefix(func() (annotationGetter, error) {
+		storageUniqueID, err := a.getStorageUniqPrefix(config.Filesystems, func() (annotationGetter, error) {
 			return ss, getErr
 		})
 		if err != nil {
@@ -326,7 +326,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 		} else if getErr != nil {
 			return errors.Trace(getErr)
 		}
-		storageUniqueID, err := a.getStorageUniqPrefix(func() (annotationGetter, error) {
+		storageUniqueID, err := a.getStorageUniqPrefix(config.Filesystems, func() (annotationGetter, error) {
 			return d, getErr
 		})
 		if err != nil {
@@ -367,7 +367,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 
 		applier.Apply(&deployment)
 	case caas.DeploymentDaemon:
-		storageUniqueID, err := a.getStorageUniqPrefix(func() (annotationGetter, error) {
+		storageUniqueID, err := a.getStorageUniqPrefix(config.Filesystems, func() (annotationGetter, error) {
 			return a.getDaemonSet()
 		})
 		if err != nil {
@@ -1911,7 +1911,7 @@ type annotationGetter interface {
 	GetAnnotations() map[string]string
 }
 
-func (a *app) getStorageUniqPrefix(getMeta func() (annotationGetter, error)) (string, error) {
+func (a *app) getStorageUniqPrefix(filesystems []jujustorage.KubernetesFilesystemParams, getMeta func() (annotationGetter, error)) (string, error) {
 	if r, err := getMeta(); err == nil {
 		// TODO: remove this function with existing one once we consolidated the annotation keys.
 		if uniqID := r.GetAnnotations()[utils.AnnotationKeyApplicationUUID(a.labelVersion)]; len(uniqID) > 0 {
@@ -1919,6 +1919,11 @@ func (a *app) getStorageUniqPrefix(getMeta func() (annotationGetter, error)) (st
 		}
 	} else if !errors.IsNotFound(err) {
 		return "", errors.Trace(err)
+	}
+	for _, fsParams := range filesystems {
+		if prefix, ok := fsParams.Attributes["pvc-prefix"]; ok {
+			return prefix.(string), nil
+		}
 	}
 	return a.randomPrefix()
 }

--- a/caas/kubernetes/provider/storage.go
+++ b/caas/kubernetes/provider/storage.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/juju/errors"
@@ -205,6 +206,29 @@ func (v *volumeSource) AttachVolumes(ctx jujucontext.ProviderCallContext, attach
 func (v *volumeSource) DetachVolumes(ctx jujucontext.ProviderCallContext, attachParams []jujustorage.VolumeAttachmentParams) ([]error, error) {
 	// noop
 	return make([]error, len(attachParams)), nil
+}
+
+func (v *volumeSource) ImportVolume(ctx jujucontext.ProviderCallContext, volumeId string, resourceTags map[string]string) (jujustorage.VolumeInfo, error) {
+	volumeIds, err := v.ListVolumes(ctx)
+	if err != nil {
+		return jujustorage.VolumeInfo{}, err
+	}
+	if !slices.Contains(volumeIds, volumeId) {
+		return jujustorage.VolumeInfo{}, errors.NotFoundf("%s", volumeId)
+	}
+	volDescResults, err := v.DescribeVolumes(ctx, []string{volumeId})
+	if err != nil {
+		return jujustorage.VolumeInfo{}, err
+	}
+	volDescResult := volDescResults[0]
+	if volDescResult.Error != nil {
+		return jujustorage.VolumeInfo{}, volDescResult.Error
+	}
+
+	// TODO(jneo8)
+	// - Verify the pvc naming rule
+	// - Filter PVC in used
+	return *volDescResult.VolumeInfo, nil
 }
 
 func foreachVolume(volumeIds []string, f func(string) error) []error {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -732,9 +732,10 @@ func (c *DeployCommand) validateStorageByModelType() error {
 	if modelType == model.IAAS {
 		return nil
 	}
-	if len(c.AttachStorage) > 0 {
-		return errors.New("--attach-storage cannot be used on k8s models")
-	}
+	// Note(jneo8): Temporary remove the check for attach storage on k8s models.
+	// if len(c.AttachStorage) > 0 {
+	// 	return errors.New("--attach-storage cannot be used on k8s models")
+	// }
 	return nil
 }
 

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -84,7 +84,8 @@ the volume and filesystem contained within.
 // importFilesystemCommand imports filesystems into the model.
 type importFilesystemCommand struct {
 	StorageCommandBase
-	modelcmd.IAASOnlyCommand
+	// Note(jneo8): Temporary disable IAAS only
+	// modelcmd.IAASOnlyCommand
 	newAPIFunc NewStorageImporterFunc
 
 	storagePool       string

--- a/rpc/params/kubernetes.go
+++ b/rpc/params/kubernetes.go
@@ -42,12 +42,13 @@ type KubernetesProvisioningInfoResults struct {
 
 // KubernetesFilesystemParams holds the parameters for creating a storage filesystem.
 type KubernetesFilesystemParams struct {
-	StorageName string                                `json:"storagename"`
-	Size        uint64                                `json:"size"`
-	Provider    string                                `json:"provider"`
-	Attributes  map[string]interface{}                `json:"attributes,omitempty"`
-	Tags        map[string]string                     `json:"tags,omitempty"`
-	Attachment  *KubernetesFilesystemAttachmentParams `json:"attachment,omitempty"`
+	StorageName   string                                `json:"storagename"`
+	Size          uint64                                `json:"size"`
+	Provider      string                                `json:"provider"`
+	Attributes    map[string]interface{}                `json:"attributes,omitempty"`
+	Tags          map[string]string                     `json:"tags,omitempty"`
+	Attachment    *KubernetesFilesystemAttachmentParams `json:"attachment,omitempty"`
+	FileSystemIds []string                              `json:"filesystem-ids,omitempty"`
 }
 
 // KubernetesFilesystemAttachmentParams holds the parameters for

--- a/storage/kubernetes.go
+++ b/storage/kubernetes.go
@@ -27,6 +27,8 @@ type KubernetesFilesystemParams struct {
 	// Attachment identifies the mount point the filesystem should be
 	// mounted at.
 	Attachment *KubernetesFilesystemAttachmentParams
+
+	FileSystemIds []string
 }
 
 // KubernetesFilesystemAttachmentParams is a set of parameters for filesystem attachment


### PR DESCRIPTION
- Import existing pvc with import-filesystem command.
- Allow to deploy k8s charm with --attach-storage command.
- Change the logic how to create the statefulset volume storage unique id.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
